### PR TITLE
新增广东技术师范大学含网络与新媒体专业的学院名及URL,及个人信息

### DIFF
--- a/list.csv
+++ b/list.csv
@@ -1,3 +1,4 @@
 学校,所在学院,URL,学号,姓名
 中山大学南方学院,文学与传媒学院,http://wcy.nfu.edu.cn/a/xueyuangaikuang/zhuanyeshezhi/wangluoyuxinmeitix/,181025070,李雯
+广东技术师范大学,文学与传媒学院,http://wxycb.gpnu.edu.cn/,181035022,彭靖茜
 


### PR DESCRIPTION
新增广东技术师范大学含网络与新媒体专业的学院名及URL,及个人信息